### PR TITLE
fix balls bounding around screen

### DIFF
--- a/static/balls.js
+++ b/static/balls.js
@@ -177,8 +177,11 @@ function Initialize(containerId) {
     gTopGroupId = containerId + '_topGroup';
     var svg = d3.select("#" + containerId).append("svg")
         .attr("id", gCanvasId)
-        .attr("width", width)
-        .attr("height", height)
+        .attr("width", "100%")
+        .attr("height", "100%")
+        .style("position", "absolute")
+        .style("top", 0)
+        .style("left", 0)
         .append("g")
         .attr("id", gTopGroupId)
         .attr("x", 0)


### PR DESCRIPTION
Previously the border they would bounce around was not the same as the screen height and width